### PR TITLE
Fix + ajout d'option

### DIFF
--- a/shanoir2bids.py
+++ b/shanoir2bids.py
@@ -372,7 +372,7 @@ Search Text : "{}" \n""".format(search_txt)
                         Path(bids_data_dir).mkdir(parents=True, exist_ok=True)
 
                         # Extract the downloaded archive
-                        dl_archive = glob(opj(self.dl_dir, item['id'] + '*.zip'))[0]
+                        dl_archive = glob(opj(self.dl_dir, '*' + item['id'] + '*.zip'))[0]
                         with zipfile.ZipFile(dl_archive, 'r') as zip_ref:
                             zip_ref.extractall(tmp_dir)
                         # Get the list of files in the archive

--- a/shanoir2bids.py
+++ b/shanoir2bids.py
@@ -568,6 +568,7 @@ def main():
     # Add the argument for the configuration file
     parser.add_argument('-j', '--config_file', required=True, help='Path to the .json configuration file specifying parameters for shanoir downloading.')
     parser.add_argument('-L', '--longitudinal', required=False, action='store_true', help='Toggle longitudinal approach.')
+    parser.add_argument('-a', '--automri', action='store_true', help='Switch to automri file tree.')
     # Parse arguments
     args = parser.parse_args()
 
@@ -579,6 +580,8 @@ def main():
     stb.set_download_directory(dl_dir=args.output_folder)  # output folder (if None a default directory is created)
     if args.longitudinal:
         stb.toggle_longitudinal_version()
+    if args.automri:
+        stb.switch_to_automri_format()
     stb.download()
 
 


### PR DESCRIPTION
Shanoir a évolué et quand un `.zip` est téléchargé, le `datesetId` apparaît en préfixe.
Petit fix pour bien localiser le fichier zip.
+ Ajout d'une option utilisateur du script shanoir2bids pour télécharger les données en format compatible pour les projets `automri`.
