### PR TITLE
[ENH] added explicit conda command installation for shanoir2bids

### DIFF
--- a/.github/workflows/conda-installation.yml
+++ b/.github/workflows/conda-installation.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         shell:  bash -el {0}
         run: |
-          conda install -c conda-forge -c https://conda.anaconda.org/simpleitk SimpleITK brotli certifi charset-normalizer dicom-anonymizer idna importlib-metadata 'numpy<2.0' pandas py7zr pybcj pycryptodomex pyppmd pytz pydicom python-dotenv python-dateutil  requests six texttable tqdm typing_extensions urllib3 zipp pydicom dicom2nifti Pillow  heudiconv git-annex=*=alldep* datalad
+          conda install -c conda-forge -c https://conda.anaconda.org/simpleitk SimpleITK brotli bids-validator certifi charset-normalizer dicom-anonymizer idna importlib-metadata 'numpy<2.0' pandas py7zr pybcj pycryptodomex pyppmd pytz pydicom python-dotenv python-dateutil  requests six texttable tqdm typing_extensions urllib3 zipp pydicom dicom2nifti Pillow  heudiconv git-annex=*=alldep* datalad
 
       # Create virtual env under each python version
       # (optional and a bit redundant because we are already on a specific python)

--- a/.github/workflows/conda-installation.yml
+++ b/.github/workflows/conda-installation.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         shell:  bash -el {0}
         run: |
-          conda install -c conda-forge -c https://conda.anaconda.org/simpleitk SimpleITK brotli certifi charset-normalizer dicom-anonymizer idna importlib-metadata numpy pandas py7zr pybcj pycryptodomex pyppmd pytz pydicom python-dotenv python-dateutil  requests six texttable tqdm typing_extensions urllib3 zipp pydicom dicom2nifti Pillow  heudiconv git-annex=*=alldep* datalad
+          conda install -c conda-forge -c https://conda.anaconda.org/simpleitk SimpleITK brotli certifi charset-normalizer dicom-anonymizer idna importlib-metadata 'numpy<2.0' pandas py7zr pybcj pycryptodomex pyppmd pytz pydicom python-dotenv python-dateutil  requests six texttable tqdm typing_extensions urllib3 zipp pydicom dicom2nifti Pillow  heudiconv git-annex=*=alldep* datalad
 
       # Create virtual env under each python version
       # (optional and a bit redundant because we are already on a specific python)

--- a/.github/workflows/conda-installation.yml
+++ b/.github/workflows/conda-installation.yml
@@ -22,10 +22,7 @@ jobs:
       - name: Install dependencies
         shell:  bash -el {0}
         run: |
-          conda config --set pip_interop_enabled True
-          python -m pip install .
-          conda update --all
-          conda install -c conda-forge heudiconv bids-validator dcm2niix git-annex=*=alldep* datalad 
+          conda install -c conda-forge -c https://conda.anaconda.org/simpleitk SimpleITK brotli certifi charset-normalizer dicom-anonymizer idna importlib-metadata numpy pandas py7zr pybcj pycryptodomex pyppmd pytz pydicom python-dotenv python-dateutil  requests six texttable tqdm typing_extensions urllib3 zipp pydicom dicom2nifti Pillow  heudiconv git-annex=*=alldep* datalad
 
       # Create virtual env under each python version
       # (optional and a bit redundant because we are already on a specific python)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In an active conda virtual environment type
 ```bash
 #use pip packages as dependencies
 # install missing conda packages (far simpler than using pip)
-conda install -c conda-forge -c https://conda.anaconda.org/simpleitk SimpleITK brotli certifi charset-normalizer dicom-anonymizer idna importlib-metadata 'numpy<2.0' pandas py7zr pybcj pycryptodomex pyppmd pytz pydicom python-dotenv python-dateutil  requests six texttable tqdm typing_extensions urllib3 zipp pydicom dicom2nifti Pillow  heudiconv git-annex=*=alldep* datalad
+conda install -c conda-forge -c https://conda.anaconda.org/simpleitk SimpleITK brotli bids-validator certifi charset-normalizer dicom-anonymizer idna importlib-metadata 'numpy<2.0' pandas py7zr pybcj pycryptodomex pyppmd pytz pydicom python-dotenv python-dateutil  requests six texttable tqdm typing_extensions urllib3 zipp pydicom dicom2nifti Pillow  heudiconv git-annex=*=alldep* datalad
 
 ```
 ## Usage

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In an active conda virtual environment type
 ```bash
 #use pip packages as dependencies
 # install missing conda packages (far simpler than using pip)
-conda install -c conda-forge -c https://conda.anaconda.org/simpleitk SimpleITK brotli certifi charset-normalizer dicom-anonymizer idna importlib-metadata numpy pandas py7zr pybcj pycryptodomex pyppmd pytz pydicom python-dotenv python-dateutil  requests six texttable tqdm typing_extensions urllib3 zipp pydicom dicom2nifti Pillow  heudiconv git-annex=*=alldep* datalad
+conda install -c conda-forge -c https://conda.anaconda.org/simpleitk SimpleITK brotli certifi charset-normalizer dicom-anonymizer idna importlib-metadata 'numpy<2.0' pandas py7zr pybcj pycryptodomex pyppmd pytz pydicom python-dotenv python-dateutil  requests six texttable tqdm typing_extensions urllib3 zipp pydicom dicom2nifti Pillow  heudiconv git-annex=*=alldep* datalad
 
 ```
 ## Usage

--- a/README.md
+++ b/README.md
@@ -23,12 +23,9 @@ Optionally, rename the `.env.example` to `.env` and set the variables (`shanoir_
 In an active conda virtual environment type 
 ```bash
 #use pip packages as dependencies
-conda config --set pip_interop_enabled True
-pip install . 
-#replace pip packages with conda packages when equivalent
-conda update --all
 # install missing conda packages (far simpler than using pip)
-conda install -c conda-forge heudiconv git-annex=*=alldep* datalad
+conda install -c conda-forge -c https://conda.anaconda.org/simpleitk SimpleITK brotli certifi charset-normalizer dicom-anonymizer idna importlib-metadata numpy pandas py7zr pybcj pycryptodomex pyppmd pytz pydicom python-dotenv python-dateutil  requests six texttable tqdm typing_extensions urllib3 zipp pydicom dicom2nifti Pillow  heudiconv git-annex=*=alldep* datalad
+
 ```
 ## Usage
 


### PR DESCRIPTION
Previously there was two similar installations: 
+ one involving pip + conda (to handle datalad installation without root access)
+ one involving pip only
The former was required to install dependencies of shanoir2bids.py script.
It was working but was introducing a warning that could be annoying about urrlib incompatibilities.
To solve this the former installation is now pure conda installation of the package 

Pros: 
+ conda is now properly handling the dependencies and thus the warning no longer exist

Cons: 
+ two different installation, hence twice the amount of CI tests (already done before)