### PR TITLE
Fix dup underscore

### DIFF
--- a/shanoir2bids.py
+++ b/shanoir2bids.py
@@ -200,7 +200,12 @@ def generate_bids_heuristic_file(
     heuristic = f"""from heudiconv.heuristics.reproin import create_key
 
 def create_bids_key(dataset):
-
+    split_filename = dataset['bidsName'].split('_')
+    # insert additional run key to dissociate indentical scans
+    file_suffix = "_".join(split_filename[:-1]) + '_' + r"run-{{item:02d}}_" + split_filename[-1]
+    if len(split_filename) == 1:
+        # remove unwanted first "_" 
+        file_suffix = file_suffix[1:]
     template = create_key(subdir=dataset['bidsDir'],file_suffix="_".join(dataset['bidsName'].split('_')[:-1]) + '_' + r"run-{{item:02d}}_" + dataset['bidsName'].split('_')[-1],outtype={outtype})
     return template
 

--- a/shanoir2bids.py
+++ b/shanoir2bids.py
@@ -221,7 +221,6 @@ def create_bids_key(dataset):
         if len(split_filename) == 1:
             # remove unwanted first "_" 
             file_suffix = file_suffix[1:]
-    print(file_suffix)
     template = create_key(subdir=dataset['bidsDir'],file_suffix=file_suffix,outtype={outtype})
     return template
 

--- a/shanoir2bids.py
+++ b/shanoir2bids.py
@@ -205,22 +205,29 @@ def create_bids_key(dataset):
 
     from heudiconv.bids import BIDSFile 
     
-    bids_entities = BIDSFile._known_entities 
-    # check where to insert run key 
-    split_keyword = '_' # default
-    for entity in bids_entities[bids_entities.index('run') + 1 :]:
-        if entity in dataset['bidsName']:
-            split_keyword = '_' + entity
-            break 
-    split_filename = dataset['bidsName'].split(split_keyword)
-    if split_keyword != '_':
-        file_suffix = "".join(split_filename[:-1]) + '_' +  r"run-{{item:02d}}" +  split_keyword  +  split_filename[-1]
+    # check if run key is already used in filename 
+    # (could be done in Pybids or using heudiconv utils?) 
+    
+    if not '_run-' in  dataset['bidsName']:
+        bids_entities = BIDSFile._known_entities 
+        # insert additional run key to dissociate identical scans
+        # check where to insert run key 
+        split_keyword = '_' # default
+        for entity in bids_entities[bids_entities.index('run') + 1 :]:
+            if entity in dataset['bidsName']:
+                split_keyword = '_' + entity
+                break 
+        split_filename = dataset['bidsName'].split(split_keyword)
+        if split_keyword != '_':
+            file_suffix = "".join(split_filename[:-1]) + '_' +  r"run-{{item:02d}}" +  split_keyword  +  split_filename[-1]
+        else:
+      
+            file_suffix = "_".join(split_filename[:-1]) + '_' + r"run-{{item:02d}}" + split_keyword + split_filename[-1]
+            if len(split_filename) == 1:
+                # remove unwanted first "_" 
+                file_suffix = file_suffix[1:]
     else:
-    # insert additional run key to dissociate identical scans
-        file_suffix = "_".join(split_filename[:-1]) + '_' + r"run-{{item:02d}}" + split_keyword + split_filename[-1]
-        if len(split_filename) == 1:
-            # remove unwanted first "_" 
-            file_suffix = file_suffix[1:]
+        file_suffix = dataset['bidsName']
     template = create_key(subdir=dataset['bidsDir'],file_suffix=file_suffix,outtype={outtype})
     return template
 

--- a/shanoir2bids.py
+++ b/shanoir2bids.py
@@ -206,7 +206,7 @@ def create_bids_key(dataset):
     if len(split_filename) == 1:
         # remove unwanted first "_" 
         file_suffix = file_suffix[1:]
-    template = create_key(subdir=dataset['bidsDir'],file_suffix="_".join(dataset['bidsName'].split('_')[:-1]) + '_' + r"run-{{item:02d}}_" + dataset['bidsName'].split('_')[-1],outtype={outtype})
+    template = create_key(subdir=dataset['bidsDir'],file_suffix=file_suffix,outtype={outtype})
     return template
 
 def get_dataset_to_key_mapping(shanoir2bids):
@@ -219,7 +219,9 @@ def get_dataset_to_key_mapping(shanoir2bids):
 def simplify_runs(info):
     info_final = dict()
     for key in info.keys():
+        print(key)
         if len(info[key])==1:
+            print('Simplified key', key)
             new_template = key[0].replace('run-{{item:02d}}_','')
             new_key = (new_template, key[1], key[2])
             info_final[new_key] = info[key]
@@ -723,7 +725,7 @@ Search Text : "{}" \n""".format(
                     "overwrite": True,
                 }
 
-                if self.longitudinal:
+                if self.longitudinal and bids_seq_session is not None:
                     workflow_params["session"] = bids_seq_session
                 try:
                     workflow(**workflow_params)


### PR DESCRIPTION
There were few duplicated underscores in file naming if the initial bidsName did not contain any separator
I also added:

-  correct run key insertion according to BIDS specification 
-  default run key support if specified by the user
- better BIDS validation (subject name is now sanitized the same way than in heudiconv) 

